### PR TITLE
修改接口文档图片保存地址

### DIFF
--- a/API.md
+++ b/API.md
@@ -843,7 +843,7 @@ POST
 {
   status: 1,
   image_path: '15bfafa418322.jpeg'  
-  // 图片保存至七牛，图片全部地址为， http://images.cangdu.org/15bfafa418322.jpeg
+  // 图片保存至七牛，图片全部地址为， https://elm.cangdu.org/img/15bfafa418322.jpeg
 }
 ```
 


### PR DESCRIPTION
上传图片接口中返回示例的图片保存地址不对，经测试发现地址应为 https://elm.cangdu.org/img/xxx.jpeg