### PR TITLE
fix dynamic RegExp generation

### DIFF
--- a/controller/shopping/shop.js
+++ b/controller/shopping/shop.js
@@ -320,7 +320,7 @@ class Shop extends AddressComponent{
 		}
 		
 		try{
-			const restaurants = await ShopModel.find({name: eval('/' + keyword + '/gi')}, '-_id').limit(50);
+			const restaurants = await ShopModel.find({name: new RegExp(String(keyword), 'gi')}, '-_id').limit(50);
 			if (restaurants.length) {
 				const [latitude, longitude] = geohash.split(',');
 				const from = latitude + ',' + longitude;

--- a/controller/statis/statis.js
+++ b/controller/statis/statis.js
@@ -77,7 +77,7 @@ class Statis {
 			return
 		}
 		try{
-			const count = await UserInfoModel.find({registe_time: eval('/^' + date + '/gi')}).count()
+			const count = await UserInfoModel.find({registe_time: new RegExp(`^${date}`, 'gi')}).count()
 			res.send({
 				status: 1,
 				count,
@@ -103,7 +103,7 @@ class Statis {
 			return
 		}
 		try{
-			const count = await AdminModel.find({create_time: eval('/^' + date + '/gi')}).count()
+			const count = await AdminModel.find({create_time: new RegExp(`^${date}`, 'gi')}).count()
 			res.send({
 				status: 1,
 				count,
@@ -129,7 +129,7 @@ class Statis {
 			return
 		}
 		try{
-			const count = await OrderModel.find({formatted_created_at: eval('/^' + date + '/gi')}).count()
+			const count = await OrderModel.find({formatted_created_at: new RegExp(`^${date}`, 'gi')}).count()
 			res.send({
 				status: 1,
 				count,


### PR DESCRIPTION
It is insecure to use `eval()` for turning user input into a regular expression, native way of doing this would be to utilize RegExp consturctor `new RegExp()`.